### PR TITLE
get current figure after ecg_plot

### DIFF
--- a/osl/report/raw_report.py
+++ b/osl/report/raw_report.py
@@ -510,7 +510,8 @@ def plot_ecg_summary(raw, savebase=None):
 
     # Process first ECG channel
     signals, info = nk.ecg_process(x[0, :], sampling_rate=raw.info['sfreq'])
-    fig = nk.ecg_plot(signals, sampling_rate=raw.info['sfreq'])
+    nk.ecg_plot(signals, sampling_rate=raw.info['sfreq'])
+    fig = plt.gcf()
     fig.set_size_inches(16, 7)
 
     # Save


### PR DESCRIPTION
Since `nk.ecg_plot` doesn't return a figure, get the figure explicitly after plotting.