### PR TITLE
bug:simulation tutorial

### DIFF
--- a/doc/source/tutorials/osl_tutorial_preproc.py
+++ b/doc/source/tutorials/osl_tutorial_preproc.py
@@ -50,6 +50,6 @@ raw.plot(n_channels=30)
 
 #%%
 
-raw = osl.preprocessing.batch.detect_badsegments(raw, segment_len=150)
+raw = osl.preprocessing.osl_wrappers.detect_badsegments(raw, segment_len=150)
 
 raw.plot(n_channels=30)


### PR DESCRIPTION
Replace `osl.preprocessing.batch.detect_badsegments` (which doesn't exist) with `osl.preprocessing.osl_wrappers.detect_badsegments` (which does).