### PR TITLE
FIX: fix log filenames in multistage and 3stage

### DIFF
--- a/osl/maxfilter/maxfilter.py
+++ b/osl/maxfilter/maxfilter.py
@@ -331,7 +331,7 @@ def run_multistage_maxfilter(infif, outbase, args):
         if key in args:
             stage1_args[key] = args[key]
 
-    outfif, outlog = run_maxfilter(infif, outfif, stage1_args, '_autobad')
+    outfif, outlog = run_maxfilter(infif, outfif, stage1_args)
 
     if args['dryrun'] is False:
         # Read in bad channels from logfile
@@ -366,7 +366,7 @@ def run_multistage_maxfilter(infif, outbase, args):
         if key in args:
             stage2_args[key] = args[key]
 
-    outfif, outlog = run_maxfilter(infif, outfif, stage2_args, '_tsss')
+    outfif, outlog = run_maxfilter(infif, outfif, stage2_args)
 
     # --------------------------------------
     # Stage 3 - Translate to reference file
@@ -387,7 +387,7 @@ def run_multistage_maxfilter(infif, outbase, args):
             if key in args:
                 stage3_args[key] = args[key]
 
-        outfif, outlog = run_maxfilter(infif, outfif, stage3_args, '_trans')
+        outfif, outlog = run_maxfilter(infif, outfif, stage3_args)
 
 
 def run_cbu_3stage_maxfilter(infif, outbase, args):
@@ -415,7 +415,7 @@ def run_cbu_3stage_maxfilter(infif, outbase, args):
         if key in args:
             stage1_args[key] = args[key]
 
-    outfif, outlog = run_maxfilter(infif, outfif, stage1_args, '_autobad')
+    outfif, outlog = run_maxfilter(infif, outfif, stage1_args)
 
     if args['dryrun'] is False:
         # Read in bad channels from logfile
@@ -452,7 +452,7 @@ def run_cbu_3stage_maxfilter(infif, outbase, args):
         if key in args:
             stage2_args[key] = args[key]
 
-    outfif, outlog = run_maxfilter(infif, outfif, stage2_args, '_tsss')
+    outfif, outlog = run_maxfilter(infif, outfif, stage2_args)
 
     # --------------------------------------
     # Stage 3 - Translate to default
@@ -473,7 +473,7 @@ def run_cbu_3stage_maxfilter(infif, outbase, args):
         if key in args:
             stage3_args[key] = args[key]
 
-    outfif, outlog = run_maxfilter(infif, outfif, stage3_args, '_trans')
+    outfif, outlog = run_maxfilter(infif, outfif, stage3_args)
 
 
 # -------------------------------------------------


### PR DESCRIPTION
Fixes #27 

in `run_multistage_maxfilter`, the [autobad extension is added to the fif file](https://github.com/OHBA-analysis/oslpy/blob/main/osl/maxfilter/maxfilter.py#L320), and then `_autobad` is given as a logfile_tag in the call to `run_maxfilter`. Because the filename of the log and error log is based on the fif file already, `autobad` is added twice. This also holds for the `tsss` and `trans` extensions.
The same is true for `run_cbu_3stage_maxfilter`.

I removed the logfile_tags in these functions to resolve this issue.