### PR TITLE
Changed order of run_proc_chain arguments for consistency.

### DIFF
--- a/doc/source/tutorials/osl_tutorial_preproc_wakehen.py
+++ b/doc/source/tutorials/osl_tutorial_preproc_wakehen.py
@@ -89,11 +89,11 @@ print(config['preproc'][0])
 yaml.dump(config, open(outdir + 'config.yaml', 'w'))
 
 #%% And now run the the preprocessing on a single dataset. We can either use the config we specified before, or load it from disk.
-dataset = osl.preprocessing.run_proc_chain(raw, config)
+dataset = osl.preprocessing.run_proc_chain(config, raw)
 
 # alternative:
 config_from_file = osl.preprocessing.load_config(outdir + 'config.yaml')
-dataset = osl.preprocessing.run_proc_chain(raw, config_from_file)
+dataset = osl.preprocessing.run_proc_chain(config_from_file, raw)
 
 #%% `dataset` is a python dictionary that contains the preprocessed data and its derivatives: raw, ica, epochs, events, and event_id, which are all in the standard MNE-python format. Under the hood, all preprocessing calls in OSL, including those to MNE-python functions, have a dataset as input and as output argument.
 dataset.keys()
@@ -137,7 +137,7 @@ def ica_kurtosisreject(dataset, userargs):
 config['preproc'][14] = {'method': 'ica_kurtosisreject'}
 
 # Now that our config contains a method that is not part of the OSL toolbox, we have to add the function as a user argument to `run_proc_chain` or `run_proc_batch`. This is done by specifying the argument `extra_funcs`. This is the command to run the preprocessing with the custom function on a single dataset:
-dataset=osl.preprocessing.run_proc_chain(raw, config, extra_funcs=[ica_kurtosisreject])
+dataset=osl.preprocessing.run_proc_chain(config, raw, extra_funcs=[ica_kurtosisreject])
 
 # or on all datasets
 osl.preprocessing.run_proc_batch(config, list_of_raw_files, outdir, overwrite=True, extra_funcs=[ica_kurtosisreject])

--- a/examples/self_paced_fingertap/self_paced_fingertap.py
+++ b/examples/self_paced_fingertap/self_paced_fingertap.py
@@ -53,7 +53,7 @@ if run_preproc:
 
     # Process a single file, this outputs fif_file
     dataset = osl.preprocessing.run_proc_chain(
-        ds_file, config, outdir=op.join(subjects_dir, subject), overwrite=True
+        config, ds_file, outdir=op.join(subjects_dir, subject), overwrite=True
     )
 
 # ------------

--- a/examples/wakeman_henson/wakeman_henson.py
+++ b/examples/wakeman_henson/wakeman_henson.py
@@ -93,7 +93,7 @@ config = """
 
 # Run preprocessing
 osl.preprocessing.run_proc_chain(
-    in_fif_file, config, outdir=preproc_dir, overwrite=True
+    config, in_fif_file, outdir=preproc_dir, overwrite=True
 )
 
 # Load preprocessed data

--- a/osl/preprocessing/README.md
+++ b/osl/preprocessing/README.md
@@ -35,7 +35,7 @@ outdir = '/where/do/i/want/my/output_dir'
 # Process a single file
 raw_file = '/path/to/file.fif'
 
-osl.preprocessing.run_proc_chain(raw_file, outdir)  # creates /path/to/file_preproc_raw.fif
+osl.preprocessing.run_proc_chain(config, raw_file, outdir)  # creates /path/to/file_preproc_raw.fif
 
 # Process a list of files
 list_of_raw_files = ['/path/to/file1.fif','/path/to/file2.fif','/path/to/file3.fif']
@@ -74,7 +74,7 @@ The following code runs the chain on a file:
 ```
 fname = '/path/to/my/dataset.fif'
 
-osl.preprocessing.run_proc_chain(fname, config)  # creates dataset_preproc_raw.fif and dataset_epo.fif
+osl.preprocessing.run_proc_chain(config, fname)  # creates dataset_preproc_raw.fif and dataset_epo.fif
 
 # Average the epochs object and visualise a response
 epochs = mne.io.read_raw_fif('/path/to/my/dataset_epo.fif')

--- a/osl/preprocessing/batch.py
+++ b/osl/preprocessing/batch.py
@@ -528,8 +528,8 @@ def plot_preproc_flowchart(
 
 
 def run_proc_chain(
-    infile,
     config,
+    infile,
     outname=None,
     outdir=None,
     logsdir=None,
@@ -848,7 +848,7 @@ def run_proc_batch(
     # Loop through input files to generate arguments for run_proc_chain
     args = []
     for infile, outname in zip(infiles, outnames):
-        args.append((infile, config, outname))
+        args.append((config, infile, outname))
 
     # Actually run the processes
     if dask_client:

--- a/osl/report/raw_report.py
+++ b/osl/report/raw_report.py
@@ -33,7 +33,6 @@ from ..utils.logger import log_or_print
 from ..preprocessing import (
     read_dataset,
     load_config,
-    run_proc_chain,
     get_config_from_fif,
     plot_preproc_flowchart,
 )

--- a/osl/tests/test_batch_preproc.py
+++ b/osl/tests/test_batch_preproc.py
@@ -43,7 +43,7 @@ class TestPreprocessingChain(unittest.TestCase):
           - bad_segments:   {segment_len: 800, picks: 'grad'}
         """
 
-        dataset = run_proc_chain(self.fpath, cfg)
+        dataset = run_proc_chain(cfg, self.fpath)
 
         # Just testing that things run not that the outputs are sensible...
         assert(isinstance(dataset["raw"], mne.io.fiff.raw.Raw))


### PR DESCRIPTION
Fixes: https://github.com/OHBA-analysis/oslpy/issues/51.

Swapped the order of the input file and config in run_proc_chain so that all batch processing functions have a consistent argument ordering.