### PR TITLE
gen_report is now overridable by user

### DIFF
--- a/osl/preprocessing/batch.py
+++ b/osl/preprocessing/batch.py
@@ -589,7 +589,7 @@ def run_proc_chain(
 
         # Generate a report by default, this is overriden if the user passes
         # gen_report=False
-        gen_report = gen_report or True
+        gen_report = True if gen_report is None else gen_report
 
         # Create output directories if they don't exist
         outdir = validate_outdir(outdir)


### PR DESCRIPTION
gen_report was always set to True, even when the user passes False.

I fixed this, so this should now behave as originally intended, i.e. set it True, if the user doesn't specify the gen_report argument, otherwise keep the user-specified argument.