### PR TITLE
fixed digitisation in report and html page issue

### DIFF
--- a/osl/preprocessing/batch.py
+++ b/osl/preprocessing/batch.py
@@ -722,12 +722,13 @@ def run_proc_chain(
 
     # Generate report data
     if gen_report:
-        from ..report import gen_html_data  # avoids circular import
+        from ..report import gen_html_data, gen_html_page  # avoids circular import
         logger.info("{0} : Generating Report".format(now))
-        reportdir = validate_outdir(reportdir / run_id)
+        report_data_dir = validate_outdir(reportdir / run_id)
         gen_html_data(
-            dataset["raw"], reportdir, ica=dataset["ica"], logger=logger
+            dataset["raw"], report_data_dir, ica=dataset["ica"], logger=logger
         )
+        gen_html_page(reportdir)
 
     if ret_dataset:
         return dataset

--- a/osl/report/raw_report.py
+++ b/osl/report/raw_report.py
@@ -122,8 +122,11 @@ def gen_html_data(raw, outdir, ica=None, logger=None):
     # Head digitisation
     dig_codes = ('Cardinal', 'HPI', 'EEG', 'Extra')
     dig_counts = np.zeros((4,))
-    for ii in range(1, 5):
-        dig_counts[ii-1] = np.sum([d['kind'] == ii for d in raw.info['dig']])
+
+    # Only run this if digitisation is available
+    if raw.info['dig']:
+        for ii in range(1, 5):
+            dig_counts[ii-1] = np.sum([d['kind'] == ii for d in raw.info['dig']])
     #d, dcounts = np.unique(digs, return_counts=True)
     data['digitable'] = tabulate(np.c_[dig_codes, dig_counts], tablefmt='html',
                                  headers=['Digitisation Stage', 'Points Acquired'])
@@ -459,6 +462,10 @@ def plot_spectra(raw, savebase=None):
 
 def plot_digitisation_2d(raw, savebase=None):
     """Plots the digitisation and headshape."""
+
+    # Return if no digitisation available
+    if not raw.info['dig']:
+        return None
 
     # Make plot
     fig = plt.figure(figsize=(16, 4))


### PR DESCRIPTION
Hi,

I'm proposing 2 bug fixes.

1. html report in run_proc_chain:
It seems that a gen_html_page call was missing after gen_html_data in run_proc_chain. This means that the HTML page for the report was not generated. I verified and with the suggested modification it gets generated.

2. Digitisation in raw_report:
I think the report generation assumed there is digitisation stuff available in raw.info['dig']. But this is not the case for EEG or OPM data for example. So all I did, was to check whether raw.info['dig'] is None before accessing it in the 2 places the report generation accesses it. I checked and the report generation now works for EEG data without digitisation info.

Cheers,
Richard