### PR TITLE
Bug fix: manual_ICA OSL wrapper in MNE wrapper file; Feature: support importing EEGLAB .set files

### DIFF
--- a/osl/preprocessing/batch.py
+++ b/osl/preprocessing/batch.py
@@ -118,6 +118,13 @@ def import_data(infile, preload=True):
         )
         raw = mne.io.read_raw_brainvision(infile, preload=preload)
 
+    # EEGLAB .set
+    elif os.path.splitext(infile)[1] == ".set":
+        logger.info(
+            "Detected EEGLAB file format, using: mne.io.read_raw_eeglab"
+        )
+        raw = mne.io.read_raw_eeglab(infile, preload=preload)
+        
     # Other formats not accepted
     else:
         msg = "Unable to determine file type of input {0}".format(infile)
@@ -712,7 +719,7 @@ def run_proc_chain(
         if ret_dataset:
             # We return an empty dict to indicate preproc failed
             # This ensures the function consistently returns one
-            # variable type
+            # variable type
             return {}
         else:
             return False

--- a/osl/preprocessing/mne_wrappers.py
+++ b/osl/preprocessing/mne_wrappers.py
@@ -386,23 +386,6 @@ def run_mne_ica_autoreject(dataset, userargs):
     return dataset
 
 
-def run_osl_ica_manualreject(dataset, userargs):
-    target = userargs.pop("target", "raw")
-    logger.info("OSL Stage - {0}".format("ICA Manual Reject"))
-    logger.info("userargs: {0}".format(str(userargs)))
-
-    from .plot_ica import plot_ica
-
-    plot_ica(dataset["ica"], dataset["raw"], block=True)
-    logger.info("Removing {0} IC".format(len(dataset["ica"].exclude)))
-    if np.logical_or("apply" not in userargs, userargs["apply"] is True):
-        logger.info("Removing selected components from raw data")
-        dataset["ica"].apply(dataset["raw"])
-    else:
-        logger.info("Components were not removed from raw data")
-    return dataset
-
-
 def run_mne_apply_ica(dataset, userargs):
     target = userargs.pop("target", "raw")
     logger.info("MNE Stage - {0}".format("ica.apply"))

--- a/osl/preprocessing/osl_wrappers.py
+++ b/osl/preprocessing/osl_wrappers.py
@@ -97,3 +97,20 @@ def run_osl_bad_channels(dataset, userargs, logfile=None):
     logger.info("userargs: {0}".format(str(userargs)))
     dataset["raw"] = detect_badchannels(dataset["raw"], **userargs)
     return dataset
+
+
+def run_osl_ica_manualreject(dataset, userargs):
+    target = userargs.pop("target", "raw")
+    logger.info("OSL Stage - {0}".format("ICA Manual Reject"))
+    logger.info("userargs: {0}".format(str(userargs)))
+
+    from .plot_ica import plot_ica
+
+    plot_ica(dataset["ica"], dataset["raw"], block=True)
+    logger.info("Removing {0} IC".format(len(dataset["ica"].exclude)))
+    if np.logical_or("apply" not in userargs, userargs["apply"] is True):
+        logger.info("Removing selected components from raw data")
+        dataset["ica"].apply(dataset["raw"])
+    else:
+        logger.info("Components were not removed from raw data")
+    return dataset

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pyyaml>=5.1
 neurokit2
 jinja2
 file-tree
+pymatreader
 # Docs
 sphinx==4.0.2
 numpydoc


### PR DESCRIPTION
**Description**:

_Bug:_ `ica_manualreject` currently fails as it is an OSL wrapper in `mne_wrappers.py` and batch.py only looks for OSL->OSL correspondence. Moved to `osl_wrappers.py`.

_Feature:_ support using EEGLAB .set files. This simply adds MNE's `read_raw_eeglab` to importing. However, as some EEGLAB versions save using .mat version 7.3+ (not supported by `scipy.io.loadmat`), MNE requires optional import of pyreadmat to be in place. This was added to requirements. 