### PR TITLE
fixed ica labels empty issue

### DIFF
--- a/osl/report/raw_report.py
+++ b/osl/report/raw_report.py
@@ -629,6 +629,11 @@ def plot_bad_ica(raw, ica, savebase):
     exclude_uniq = np.sort(np.unique(ica.exclude))[::-1]
     nbad = len(exclude_uniq)
 
+    # Handle the case when ica.labels_ is empty
+    if not ica.labels_:
+        # Make a dummy labels_ dict
+        ica.labels_ = {ica._ica_names[exc]: '' for exc in exclude_uniq}
+
     # Create figure
     fig = plt.figure(figsize=(16, 5 * nbad), facecolor=[0.95] * 3)
     axes = []

--- a/osl/report/raw_report.py
+++ b/osl/report/raw_report.py
@@ -629,8 +629,8 @@ def plot_bad_ica(raw, ica, savebase):
     exclude_uniq = np.sort(np.unique(ica.exclude))[::-1]
     nbad = len(exclude_uniq)
 
-    # Handle the case when ica.labels_ is empty
-    if not ica.labels_:
+    # Handle the case when ica.labels_ and ica.exclude don't match
+    if len(ica.labels_) != nbad:
         # Make a dummy labels_ dict
         ica.labels_ = {ica._ica_names[exc]: '' for exc in exclude_uniq}
 


### PR DESCRIPTION
Hi,

There was an inconvenience in the plot_bad_ica function because it assume ica.labels_ would not be empty, and would throw an error otherwise. I just included a check for this, and if ica.labels_ is empty, it gets initialized with empty strings, so the subsequent code doesn't throw errors.

Cheers,
Richard